### PR TITLE
Update controller to respect namespaces

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -189,7 +189,7 @@ func (c *FaultInjectorController) prepareInitialStore() error {
 	listOptions := api.ListOptions{
 		LabelSelector: selector,
 	}
-	deployments, err := c.kclient.Extensions().Deployments(v1.NamespaceDefault).List(listOptions)
+	deployments, err := c.kclient.Extensions().Deployments(v1.NamespaceAll).List(listOptions)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func (c *FaultInjectorController) prepareInitialStore() error {
 		resource := &spec.FaultInjector{
 			ObjectMeta: v1.ObjectMeta{
 				Name:      name[1],
-				Namespace: v1.NamespaceDefault,
+				Namespace: deployments.Items[i].ObjectMeta.Namespace,
 				Labels:    resourceLabels,
 			},
 			Spec: spec.FaultInjectorSpec{
@@ -258,7 +258,7 @@ func (c *FaultInjectorController) addFaultInjector(newObj *spec.FaultInjector) e
 		if err != nil {
 			return err
 		}
-		downstreamObj, err = c.kclient.Extensions().Deployments(api.NamespaceDefault).Create(downstreamObj)
+		downstreamObj, err = c.kclient.Extensions().Deployments(downstreamObj.ObjectMeta.Namespace).Create(downstreamObj)
 		if err != nil {
 			return err
 		}
@@ -267,7 +267,7 @@ func (c *FaultInjectorController) addFaultInjector(newObj *spec.FaultInjector) e
 		if err != nil {
 			return err
 		}
-		downstreamObj, err = c.kclient.Extensions().Deployments(api.NamespaceDefault).Update(downstreamObj)
+		downstreamObj, err = c.kclient.Extensions().Deployments(downstreamObj.ObjectMeta.Namespace).Update(downstreamObj)
 		if err != nil {
 			return err
 		}
@@ -279,14 +279,14 @@ func (c *FaultInjectorController) addFaultInjector(newObj *spec.FaultInjector) e
 func (c *FaultInjectorController) deleteFaultInjector(obj *spec.FaultInjector) error {
 	downstreamObj := c.getDownstreamState(obj)
 	if downstreamObj != nil {
-		err := c.kclient.Extensions().Deployments(api.NamespaceDefault).Delete(downstreamObj.ObjectMeta.Name, &api.DeleteOptions{})
+		err := c.kclient.Extensions().Deployments(downstreamObj.ObjectMeta.Namespace).Delete(downstreamObj.ObjectMeta.Name, &api.DeleteOptions{})
 		return err
 	}
 	return nil
 }
 
 func (c *FaultInjectorController) getDownstreamState(obj *spec.FaultInjector) *extensionsobj.Deployment {
-	deployment, err := c.kclient.Extensions().Deployments(v1.NamespaceDefault).Get(formatDownstreamName(obj))
+	deployment, err := c.kclient.Extensions().Deployments(obj.ObjectMeta.Namespace).Get(formatDownstreamName(obj))
 	if err != nil {
 		return nil
 	}

--- a/pkg/controller/helpers.go
+++ b/pkg/controller/helpers.go
@@ -20,7 +20,7 @@ func generateDownstreamObject(obj *spec.FaultInjector) (*extensionsobj.Deploymen
 	deploymentObj := &extensionsobj.Deployment{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      formatDownstreamName(obj),
-			Namespace: v1.NamespaceDefault,
+			Namespace: obj.ObjectMeta.Namespace,
 			Labels:    map[string]string{"generatedBy": "FaultInjector"},
 		},
 		Spec: extensionsobj.DeploymentSpec{

--- a/pkg/controller/helpers_test.go
+++ b/pkg/controller/helpers_test.go
@@ -118,7 +118,7 @@ func TestGenerateDownstreamObject(t *testing.T) {
 			expectedObj = &extensionsobj.Deployment{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      formatDownstreamName(test),
-					Namespace: v1.NamespaceDefault,
+					Namespace: test.ObjectMeta.Namespace,
 					Labels:    map[string]string{"generatedBy": "FaultInjector"},
 				},
 				Spec: extensionsobj.DeploymentSpec{
@@ -277,7 +277,7 @@ func getGenerateDownstreamObjectTests() map[string]*spec.FaultInjector {
 	tests["PodKiller-NilLabels"] = &spec.FaultInjector{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "lithium",
-			Namespace: v1.NamespaceDefault,
+			Namespace: "test-namespace-one",
 		},
 		Spec: spec.FaultInjectorSpec{
 			Type: "PodKiller",
@@ -286,7 +286,7 @@ func getGenerateDownstreamObjectTests() map[string]*spec.FaultInjector {
 	tests["NetworkLatency-EmptyLabels"] = &spec.FaultInjector{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "sodium",
-			Namespace: v1.NamespaceDefault,
+			Namespace: "test-namespace-two",
 			Labels:    make(map[string]string),
 		},
 		Spec: spec.FaultInjectorSpec{
@@ -296,7 +296,7 @@ func getGenerateDownstreamObjectTests() map[string]*spec.FaultInjector {
 	tests["PodKiller-OneLabel"] = &spec.FaultInjector{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "potassium",
-			Namespace: v1.NamespaceDefault,
+			Namespace: "test-namespace-one",
 			Labels: map[string]string{
 				"period": "four",
 			},
@@ -308,7 +308,7 @@ func getGenerateDownstreamObjectTests() map[string]*spec.FaultInjector {
 	tests["PodKiller-MultipleLabels"] = &spec.FaultInjector{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "rubidium",
-			Namespace: v1.NamespaceDefault,
+			Namespace: "test-namespace-two",
 			Labels: map[string]string{
 				"group":  "alkali",
 				"period": "four",


### PR DESCRIPTION
This updates the FaultInjectorController so that it looks for FaultInjector resources in all namespaces, and will create a downstream object in the same namespace as the FaultInjector resource, rather than in the default namespace.