### PR TITLE
Implement namespace support in PodKiller

### DIFF
--- a/cmd/podkiller/main.go
+++ b/cmd/podkiller/main.go
@@ -3,24 +3,58 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/puppetlabs/fault-injector-controller/pkg/podkiller"
 	"github.com/puppetlabs/fault-injector-controller/version"
+
+	"k8s.io/client-go/1.5/pkg/api"
 )
 
 var (
+	cfg          podkiller.Config
 	printVersion bool
 	printImage   bool
 )
 
 func init() {
+	var namespaceValue string
+	var namespaceFile string
 	flagset := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	flagset.StringVar(&namespaceValue, "namespace", "", "The namespace to work in. Mutually exclusive with -namespace-file.")
+	flagset.StringVar(&namespaceFile, "namespace-file", "", "A file containing the namespace to work in. Mutually exclusive with -namespace.")
+	flagset.StringVar(&cfg.Host, "apiserver", "", "API Server addr, e.g. ' - NOT RECOMMENDED FOR PRODUCTION - http://127.0.0.1:8080'. Omit parameter to run in on-cluster mode and utilize the service account token.")
+	flagset.StringVar(&cfg.TLSConfig.CertFile, "cert-file", "", " - NOT RECOMMENDED FOR PRODUCTION - Path to public TLS certificate file.")
+	flagset.StringVar(&cfg.TLSConfig.KeyFile, "key-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to private TLS certificate file.")
+	flagset.StringVar(&cfg.TLSConfig.CAFile, "ca-file", "", "- NOT RECOMMENDED FOR PRODUCTION - Path to TLS CA file.")
+	flagset.BoolVar(&cfg.TLSInsecure, "tls-insecure", false, "- NOT RECOMMENDED FOR PRODUCTION - Don't verify API server's CA certificate.")
 	flagset.BoolVar(&printVersion, "version", false, "Show version and quit")
 	flagset.BoolVar(&printImage, "image", false, "Show the image name for the application and quit")
 	flagset.Parse(os.Args[1:])
+
+	if namespaceValue != "" && namespaceFile != "" {
+		fmt.Fprint(os.Stderr, "Cannot specify both -namespace and -namespace-file!")
+		os.Exit(1)
+	}
+
+	// Pick whichever of namespaceValue or namespaceFile is set.
+	if namespaceValue != "" {
+		cfg.Namespace = namespaceValue
+	} else if namespaceFile != "" {
+		rawString, err := ioutil.ReadFile(namespaceFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error when attempting to read namespace from %v: %v", namespaceFile, err)
+			os.Exit(1)
+		}
+		cfg.Namespace = strings.TrimSpace(string(rawString))
+	} else {
+		cfg.Namespace = api.NamespaceDefault
+	}
 
 	rand.Seed(time.Now().UnixNano())
 }
@@ -35,7 +69,7 @@ func main() {
 		os.Exit(0)
 	}
 	fmt.Printf("FaultInjector PodKiller, version %v\n", version.Version)
-	p, err := podkiller.New()
+	p, err := podkiller.New(cfg)
 	if err != nil {
 		fmt.Fprint(os.Stderr, err)
 		os.Exit(1)

--- a/pkg/controller/helpers_test.go
+++ b/pkg/controller/helpers_test.go
@@ -128,6 +128,23 @@ func TestGenerateDownstreamObject(t *testing.T) {
 						},
 						Spec: v1.PodSpec{
 							Containers: containers,
+							Volumes: []v1.Volume{
+								v1.Volume{
+									Name: "podinfo",
+									VolumeSource: v1.VolumeSource{
+										DownwardAPI: &v1.DownwardAPIVolumeSource{
+											Items: []v1.DownwardAPIVolumeFile{
+												v1.DownwardAPIVolumeFile{
+													Path: "namespace",
+													FieldRef: &v1.ObjectFieldSelector{
+														FieldPath: "metadata.namespace",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 				},
@@ -203,7 +220,18 @@ func getGenerateDownstreamContainersTests() map[string]resourceContainerMap {
 			},
 		},
 		Containers: []v1.Container{
-			{Name: "fault-injector-podkiller", Image: fmt.Sprintf("%v/fault-injector-podkiller:%v", imagePrefix, version.Version)},
+			v1.Container{
+				Name:  "fault-injector-podkiller",
+				Image: fmt.Sprintf("%v/fault-injector-podkiller:%v", imagePrefix, version.Version),
+				Args:  []string{"-namespace-file", "/etc/namespace"},
+				VolumeMounts: []v1.VolumeMount{
+					v1.VolumeMount{
+						Name:      "podinfo",
+						MountPath: "/etc",
+						ReadOnly:  false,
+					},
+				},
+			},
 		},
 		ErrorValue: nil,
 	}

--- a/pkg/podkiller/podkiller.go
+++ b/pkg/podkiller/podkiller.go
@@ -1,7 +1,9 @@
 package podkiller
 
 import (
+	"fmt"
 	"math/rand"
+	"net/url"
 	"time"
 
 	"k8s.io/client-go/1.5/kubernetes"
@@ -12,14 +14,40 @@ import (
 
 // PodKiller deletes Pods from Kubernetes.
 type PodKiller struct {
-	kclient kubernetes.Interface
+	kclient   kubernetes.Interface
+	namespace string
+}
+
+// Config holds configuration parameters for a PodKiller.
+type Config struct {
+	Namespace   string
+	Host        string
+	TLSInsecure bool
+	TLSConfig   rest.TLSClientConfig
 }
 
 // New creates a new PodKiller.
-func New() (*PodKiller, error) {
-	cfg, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
+func New(conf Config) (*PodKiller, error) {
+	var cfg *rest.Config
+	var err error
+
+	if len(conf.Host) == 0 {
+		cfg, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		cfg = &rest.Config{
+			Host: conf.Host,
+		}
+		hostURL, err := url.Parse(conf.Host)
+		if err != nil {
+			return nil, fmt.Errorf("Error parsing host URL %s: %v", conf.Host, err)
+		}
+		if hostURL.Scheme == "https" {
+			cfg.TLSClientConfig = conf.TLSConfig
+			cfg.Insecure = conf.TLSInsecure
+		}
 	}
 
 	client, err := kubernetes.NewForConfig(cfg)
@@ -28,7 +56,8 @@ func New() (*PodKiller, error) {
 	}
 
 	return &PodKiller{
-		kclient: client,
+		kclient:   client,
+		namespace: conf.Namespace,
 	}, nil
 }
 
@@ -39,9 +68,9 @@ func (p *PodKiller) Run(interval time.Duration, stopChan <-chan struct{}) error 
 }
 
 func (p *PodKiller) killPods() {
-	allPods, err := p.kclient.Core().Pods(api.NamespaceDefault).List(api.ListOptions{})
+	allPods, err := p.kclient.Core().Pods(p.namespace).List(api.ListOptions{})
 	if err == nil && len(allPods.Items) > 0 {
 		podToKill := allPods.Items[rand.Intn(len(allPods.Items))]
-		p.kclient.Core().Pods(api.NamespaceDefault).Delete(podToKill.Name, &api.DeleteOptions{})
+		p.kclient.Core().Pods(p.namespace).Delete(podToKill.Name, &api.DeleteOptions{})
 	}
 }

--- a/podkiller.Dockerfile
+++ b/podkiller.Dockerfile
@@ -1,3 +1,4 @@
 FROM scratch
 ADD bin/podkiller /podkiller
-CMD ["/podkiller"]
+ENTRYPOINT ["/podkiller"]
+CMD ["-help"]


### PR DESCRIPTION
This adds support for namespaces to PodKiller. With this, by passing in `-namespace` or `-namespace-file` to the invocation of PodKiller, it will only kill pods within the specified namespace. If both are empty, it will using the default namespace.

This also updates the FaultInjector to add the namespace of the PodKiller Deployments it creates to the pods as a VolumeMount and passes the appropriate `-namespace-file` flag to it.